### PR TITLE
Fixed 1 issue of type: PYTHON_E225 throughout 1 file in repo.

### DIFF
--- a/django_fine_uploader/urls.py
+++ b/django_fine_uploader/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import url
 
 from . import views
 
-app_name="django_fine_uploader"
+app_name = "django_fine_uploader"
 
 urlpatterns = [
     url(r'^upload/$', views.FineUploaderView.as_view(), name='upload'),


### PR DESCRIPTION
PYTHON_E225: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.