### PR TITLE
Fixed 1 issue of type: PYTHON_E402 throughout 1 file in repo.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import django_fine_uploader
 import sys, os
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -22,7 +23,6 @@ cwd = os.getcwd()
 parent = os.path.dirname(cwd)
 sys.path.append(parent)
 
-import django_fine_uploader
 
 # -- General configuration -----------------------------------------------------
 


### PR DESCRIPTION
PYTHON_E402: 'module level import not at top of file'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.