### PR TITLE
Fixed 5 issues of type: PYTHON_F401 throughout 5 files in repo.

### DIFF
--- a/django_fine_uploader/fineuploader.py
+++ b/django_fine_uploader/fineuploader.py
@@ -1,4 +1,3 @@
-from django.conf import settings as django_settings
 
 from six.moves import range
 

--- a/example/myapp/admin.py
+++ b/example/myapp/admin.py
@@ -1,7 +1,5 @@
-import os
 import shutil
 
-from django import forms
 from django.db import models
 from django.db.models import FileField
 from django.contrib import admin

--- a/example/myapp/tests.py
+++ b/example/myapp/tests.py
@@ -1,3 +1,2 @@
-from django.test import TestCase
 
 # Create your tests here.

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -11,7 +11,7 @@ from django.test.client import Client
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
-from django_fine_uploader import views, settings, fineuploader
+from django_fine_uploader import settings, views
 from django_fine_uploader.forms import FineUploaderUploadForm
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,7 +10,6 @@ Tests for `django-fine-uploader` models module.
 
 from django.test import TestCase
 
-from django_fine_uploader import models
 
 
 class TestDjango_fine_uploader(TestCase):


### PR DESCRIPTION
PYTHON_F401: 'Module imported but unused.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.        

It was fixed with <a href='https://github.com/myint/autoflake'>autoflake</a>.        

This fix is probably safe because the module was not called anywhere.  But if the removed module had global side-effects,        these will be missing and could cause issues.        