### PR TITLE
Django 3.x changes

### DIFF
--- a/django_fine_uploader/urls.py
+++ b/django_fine_uploader/urls.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
-from django.conf.urls import url
+from django.urls import path
 
 from . import views
 
 app_name="django_fine_uploader"
 
 urlpatterns = [
-    url(r'^upload/$', views.FineUploaderView.as_view(), name='upload'),
-    url(r'^delete(/(?P<uuid>[0-9a-f-]+))?$', views.FineUploaderDeleteView.as_view(), name='delete'),
+    path('upload/', views.FineUploaderView.as_view(), name='upload'),
+    path('delete', views.FineUploaderDeleteView.as_view(), name='delete'),
+    path('delete/<uuid:uuid>', views.FineUploaderDeleteView.as_view(), name='delete'),
 ]

--- a/django_fine_uploader/views.py
+++ b/django_fine_uploader/views.py
@@ -106,7 +106,7 @@ class FineUploaderDeleteView(generic.View):
         """
         file_storage = utils.import_class(settings.FILE_STORAGE)()
         uuid = kwargs.get('uuid')
-        path = join(settings.UPLOAD_DIR, uuid)
+        path = join(settings.UPLOAD_DIR, str(uuid))
         if file_storage.exists(path):
             full_path = file_storage.path(path)
             try:

--- a/example/config/settings.py
+++ b/example/config/settings.py
@@ -43,13 +43,13 @@ INSTALLED_APPS = [
     # they should be added here
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    # 'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]

--- a/example/config/urls.py
+++ b/example/config/urls.py
@@ -14,7 +14,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
 from django.conf.urls.static import static
-from django.conf.urls import url, include
+from django.urls import path, include
 from django.contrib import admin
 from django.conf import settings
 
@@ -22,16 +22,16 @@ from myapp import views
 
 urlpatterns = [
     # The Django Admin
-    url(r'^admin/', admin.site.urls),
+    path('admin/', admin.site.urls),
 
     # django-fine-uploader default urls
-    url(r'^fine-uploader/', include('django_fine_uploader.urls', namespace='django_fine_uploader')),
+    path('fine-uploader/', include('django_fine_uploader.urls', namespace='django_fine_uploader')),
 
     # our custom views on myapp app
-    url(r'^$', view=views.ExampleView.as_view(), name='home'),
-    url(r'^widget/', view=views.ExampleWidgetView.as_view(), name='home-widget'),
-    url(r'^upload-1/$', view=views.MyAppUploaderView.as_view(), name='uploader-1'),
-    url(r'^upload-2/$', view=views.NotConcurrentUploaderView.as_view(), name='uploader-2'),
-    url(r'^upload-3/$', view=views.SimpleCustomUploaderView.as_view(), name='uploader-3'),
-    url(r'^upload-4/$', view=views.CustomFineUploaderView.as_view(), name='uploader-4'),
+    path('', view=views.ExampleView.as_view(), name='home'),
+    path('widget/', view=views.ExampleWidgetView.as_view(), name='home-widget'),
+    path('upload-1/', view=views.MyAppUploaderView.as_view(), name='uploader-1'),
+    path('upload-2/', view=views.NotConcurrentUploaderView.as_view(), name='uploader-2'),
+    path('upload-3/', view=views.SimpleCustomUploaderView.as_view(), name='uploader-3'),
+    path('upload-4/', view=views.CustomFineUploaderView.as_view(), name='uploader-4'),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/example/myapp/urls.py
+++ b/example/myapp/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import url
+from django.urls import path
 from . import views
 
 
 urlpatterns = [
-    url(r'^widget/$', view=views.ExampleWidgetView.as_view()),
+    path('widget/', views.ExampleWidgetView.as_view(), name='widget'),
 ]

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8
 from __future__ import unicode_literals, absolute_import
 
-from django.conf.urls import url, include
+from django.urls import path, include
 
 from django_fine_uploader.urls import urlpatterns as django_fine_uploader_urls
 
 urlpatterns = [
-    url(r'^', include(django_fine_uploader_urls, namespace='django_fine_uploader')),
+    path('', include('django_fine_uploader.urls', namespace='django_fine_uploader')),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py27,py34,py35,py36}-django-110
+    {py27,py34,py35,py36,py37}-django-110
 
 [testenv]
 setenv =
@@ -11,6 +11,7 @@ deps =
     -r{toxinidir}/requirements_test.txt
     -e.
 basepython =
+    py37: python3.7
     py36: python3.6
     py35: python3.5
     py34: python3.4


### PR DESCRIPTION
example/config.settings: MIDDLEWARE_CLASSES -> MIDDLEWARE.
urls: url -> path (note that UUID URL patterns result in UUID objects that must be converted to str before passing to os.path.join)
Python 3.7 environment for tox.
Passes tests.