### PR TITLE
Modified example app so that creating a `FineFile` model places the file in a custom location.

### DIFF
--- a/django_fine_uploader/fineuploader.py
+++ b/django_fine_uploader/fineuploader.py
@@ -42,6 +42,9 @@ class BaseFineUploader(object):
         file_storage = utils.import_class(self.storage_class)
         return file_storage()
 
+    def rmtree_containing_final_file(self):
+        shutil.rmtree(self.storage.path(self.file_path))
+
     def save(self):
         raise NotImplementedError
 

--- a/example/myapp/models.py
+++ b/example/myapp/models.py
@@ -4,7 +4,10 @@ from django.db import models
 
 
 def file_using_key_path(instance, filename):
-    return '{0}/{1}'.format(instance.key, filename)
+    if instance.key is not None and len(instance.key) > 0:
+        return 'fine_files/{0}/{1}'.format(instance.key, filename)
+    else:
+        return 'fine_files/{}'.format(filename)
 
 
 class FineFile(models.Model):

--- a/example/myapp/views.py
+++ b/example/myapp/views.py
@@ -1,5 +1,8 @@
+import os
+
 from django.views.decorators.csrf import csrf_exempt
 from django.http import JsonResponse
+from django.core.files import File
 from django.views import generic
 
 from django_fine_uploader.fineuploader import SimpleFineUploader
@@ -81,8 +84,12 @@ class CustomFineUploaderView(FineUploaderView):
         data = {'success': True}
         if self.upload.finished:
             data['file_url'] = self.upload.url
-            # Let's save in database?
-            FineFile.objects.create(fine_file=self.upload.real_path)
+            filename = os.path.split(self.upload.real_path)[1]
+            with self.upload.storage.open(self.upload.real_path, 'rb') as f:
+                file = File(f, name=filename)
+                # Let's save in database?
+                FineFile.objects.create(fine_file=file)
+            self.upload.rmtree_containing_final_file()
         return self.make_response(data)
 
 


### PR DESCRIPTION
The `FineFile` model file field specifies a custom path into which uploaded files are saved, but this does not happen; the file is placed into a generic `uploads` directory.
These modifications place the file in the location specified by the file field.